### PR TITLE
Removed a bad example

### DIFF
--- a/intro/src/com/hadihariri/kotlincourse/basics/LoopsAndRanges.kt
+++ b/intro/src/com/hadihariri/kotlincourse/basics/LoopsAndRanges.kt
@@ -21,10 +21,6 @@ fun main(args: Array<String>) {
         println(a)
     }
 
-    for (a in 100..1) {
-        println(a)
-    }
-
     for (b in 100 downTo 1 step 5) {
 
     }


### PR DESCRIPTION
Looping over a range of `100..1` does nothing at all, because this is an empty range.